### PR TITLE
Enhance federated simulation with robust weight handling and metric logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import argparse
+import csv
+import os
+from typing import Iterable
+
 import flwr as fl
 
 from client import ThicknessClient
@@ -10,7 +15,11 @@ from model import ModelName
 from server import get_strategy
 
 
-def run_simulation(model_name: ModelName) -> None:
+def run_simulation(
+    model_name: ModelName,
+    num_rounds: int = 3,
+    metrics_file: str | None = None,
+) -> None:
     """Run a federated simulation for the specified model."""
 
     client_partitions, test_set = load_client_data("data")
@@ -24,17 +33,75 @@ def run_simulation(model_name: ModelName) -> None:
     strategy = get_strategy(X_test, y_test, model_name)
 
     print(f"\n>>> Federated training for model: {model_name}")
-    fl.simulation.start_simulation(
+    history = fl.simulation.start_simulation(
         client_fn=client_fn,
         num_clients=len(client_partitions),
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=num_rounds),
         strategy=strategy,
     )
 
+    # ------------------------------------------------------------------
+    # Optional metric logging
+    # ------------------------------------------------------------------
+    if metrics_file:
+        rounds: Iterable[int] = sorted(
+            {r for v in history.metrics_centralized.values() for r, _ in v}
+        )
+        with open(metrics_file, "w", newline="") as fp:
+            writer = csv.writer(fp)
+            header = ["round"] + list(history.metrics_centralized.keys())
+            writer.writerow(header)
+            for rnd in rounds:
+                row = [rnd]
+                for key in history.metrics_centralized.keys():
+                    val = next(
+                        (v for r, v in history.metrics_centralized[key] if r == rnd),
+                        "",
+                    )
+                    row.append(val)
+                writer.writerow(row)
+        print(f"Saved metrics to {metrics_file}")
+    else:
+        for key, values in history.metrics_centralized.items():
+            for rnd, val in values:
+                print(f"Round {rnd:>2d} {key}: {val}")
+
 
 def main() -> None:
-    for name in ["random_forest", "xgboost", "catboost", "knn"]:
-        run_simulation(name)  # type: ignore[arg-type]
+    parser = argparse.ArgumentParser(description="Run federated simulations")
+    parser.add_argument(
+        "--model",
+        type=str,
+        choices=["random_forest", "xgboost", "catboost", "knn", "all"],
+        default="random_forest",
+        help="Which model to train. Use 'all' to iterate over every model sequentially.",
+    )
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        default=3,
+        help="Number of federated training rounds to run",
+    )
+    parser.add_argument(
+        "--log-metrics",
+        type=str,
+        default=None,
+        help="Optional path to a CSV file where global metrics will be saved",
+    )
+    args = parser.parse_args()
+
+    model_list = (
+        [args.model]
+        if args.model != "all"
+        else ["random_forest", "xgboost", "catboost", "knn"]
+    )
+
+    for name in model_list:
+        metrics_file = None
+        if args.log_metrics:
+            base, ext = os.path.splitext(args.log_metrics)
+            metrics_file = f"{base}_{name}{ext or '.csv'}"
+        run_simulation(name, num_rounds=args.rounds, metrics_file=metrics_file)  # type: ignore[arg-type]
 
 
 if __name__ == "__main__":

--- a/train_utils.py
+++ b/train_utils.py
@@ -3,20 +3,46 @@
 from __future__ import annotations
 
 import pickle
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import numpy as np
 from sklearn.metrics import mean_squared_error, r2_score
 
 
-def get_weights(model) -> List[np.ndarray]:
-    """Serialize a scikit-learn model into a list of ``np.ndarray``."""
+def get_weights(model: Any) -> List[np.ndarray]:
+    """Serialize a full scikit-learn model into a list of ``np.ndarray``.
+
+    The entire model object is pickled so that arbitrary estimators can be
+    transported between Flower server and clients without having to manually
+    extract their internal parameters.
+    """
+
     return [np.frombuffer(pickle.dumps(model), dtype=np.uint8)]
 
 
-def set_weights(weights: List[np.ndarray]):
-    """Deserialize model weights back into a scikit-learn model."""
-    return pickle.loads(weights[0].tobytes())
+def set_weights(model: Any, weights: List[np.ndarray]) -> Any:
+    """Update ``model`` with the provided serialized parameters.
+
+    ``weights`` is expected to be the output of :func:`get_weights`.  If the
+    deserialised object is of a different type than ``model`` the deserialised
+    object is returned unchanged and ``model`` is left untouched.  This makes
+    the function robust against accidentally mixing different estimator types
+    across clients.
+    """
+
+    new_model = pickle.loads(weights[0].tobytes())
+
+    # If the types match we can simply copy over the attributes which updates
+    # the model in-place.  Returning the original instance avoids the caller
+    # having to keep track of a newly created object.
+    if isinstance(new_model, type(model)):
+        model.__dict__.update(new_model.__dict__)
+        return model
+
+    # If types do not match, return the new model so the caller can decide
+    # what to do with it (e.g. replace the old model).  No exception is raised
+    # to avoid breaking the FL pipeline when model types are mismatched.
+    return new_model
 
 
 def evaluate_model(model, X: np.ndarray, y: np.ndarray) -> Tuple[float, float]:


### PR DESCRIPTION
## Summary
- prevent estimator overwrite by applying weight updates in place and handling mismatched model types
- clarify non-random-forest aggregation and support CSV metric logging per round
- allow running individual models via CLI with optional global metric logging

## Testing
- `python -m py_compile client.py main.py server.py train_utils.py`
- `python main.py --model random_forest --rounds 1 --log-metrics metrics.csv` *(fails: FileNotFoundError: No CSV files found in data)*

------
https://chatgpt.com/codex/tasks/task_e_688f3f7a8074832ab5423694a03ed172